### PR TITLE
JNG-4086 '+' and '-' operators added

### DIFF
--- a/model/src/main/java/hu/blackbelt/judo/meta/jql/JqlDsl.xtext
+++ b/model/src/main/java/hu/blackbelt/judo/meta/jql/JqlDsl.xtext
@@ -61,7 +61,7 @@ SpawnOperation returns JqlExpression:
 ;
 
 UnaryOperation returns JqlExpression:
-    {UnaryOperation} operator=OpUnary operand=FunctionedExpression
+    {UnaryOperation} operator=OpUnary operand=UnaryOperation
     | FunctionedExpression;
 
 FunctionedExpression returns JqlExpression:
@@ -83,7 +83,7 @@ FunctionCall:
     {FunctionCall} '!' function=Function features+=Feature* call=FunctionCall?;
 
 OpUnary:
-    'not' | "-";
+    'not' | '-' | '+';
 
 Feature:
     {Feature} ('.' | '->' | '=>') name=FeatureName;


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://blackbelt.atlassian.net/browse/JNG-4086" title="JNG-4086" target="_blank"><img alt="Bug" src="https://blackbelt.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />JNG-4086</a>  '+' is missing in unary operators, wrong number terminal
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
